### PR TITLE
V5.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Nik Henri",
 	"publisher": "NikHenri",
 	"description": "Nik Henri vscode extension",
-	"version": "5.1.8",
+	"version": "5.1.9",
 	"engines": {
 		"vscode": "^1.56.0"
 	},

--- a/src/completionItemsVariable.js
+++ b/src/completionItemsVariable.js
@@ -78,7 +78,7 @@ function getAllPortLabelDescFromEntity(text) {
 // bit [$clog2(SIZE)-1:0] [3:0] a [1:0][3:0];
 // type(woof)  b;
 function getAllSignalLabelDescFromArchitecture(text) {
-	let matchAllvariableLineDeclaration = Array.from(text.matchAll(/^[ ]*(?!\bassign\b|\balways_comb\b)(type\b.*?\)|\w+)[ ]*(\[.*\])*[ ]+(\w[a-zA-Z_0-9, ]*)(\[.*\])*(?:=.*)?[ ]*;/gm))
+	let matchAllvariableLineDeclaration = Array.from(text.matchAll(/^[ ]*(?!\bassign\b|\balways_comb\b)((?:var\s+)?type\b.*?\)|\w+)[ ]*(\[.*\])*[ ]+(\w[a-zA-Z_0-9, ]*)(\[.*\])*(?:=.*)?[ ]*;/gm))
 	let nameDescArray = []
 	for (let variableLineDeclaration of matchAllvariableLineDeclaration) { //extract all variable separate by ,
 		let type = variableLineDeclaration[1]

--- a/src/utils.js
+++ b/src/utils.js
@@ -103,10 +103,12 @@ function getFileText(fileNameWithoutExt) {
 function uriToFileNameWithoutExt(uri) {
 	return filePathToFileNameWithoutExt(uri.fsPath)
 }
+
 //----------------------------------------------------------------------------
 function filePathToFileNameWithoutExt(filePath) {
 	return path.parse(filePath).name
 }
+
 //----------------------------------------------------------------------------
 // Get a index/offset caracter, convert into line/char
 function indexToPosition (text, index) {
@@ -115,6 +117,7 @@ function indexToPosition (text, index) {
 	let char = lineSplit[lineSplit.length - 1].length
 	return new vscode.Position(line, char)
 }
+
 //----------------------------------------------------------------------------
 // return a name of import use in file (import oti_header_pkg::*; => return oti_header_pkg)
 function getImportNameList(fileNameWithoutExt) {
@@ -129,6 +132,7 @@ function getImportNameList(fileNameWithoutExt) {
 	}
 	return []
 }
+
 //----------------------------------------------------------------------------
 function getImportNameListInOrder(fileNameWithoutExt) {
 	let importNameListRecursive = getImportNameListRecursive(fileNameWithoutExt)
@@ -139,6 +143,7 @@ function getImportNameListInOrder(fileNameWithoutExt) {
 	}
 	return importNameListInOrder
 }
+
 //----------------------------------------------------------------------------
 function getImportNameListRecursive(fileNameWithoutExt, importList = []) {
 	// console.log(`Inspecting ${fileNameWithoutExt}`)
@@ -149,6 +154,7 @@ function getImportNameListRecursive(fileNameWithoutExt, importList = []) {
 	}
 	return importList
 }
+
 //----------------------------------------------------------------------------
 function wordIsReserved(word) {
     return word.match(new RegExp("\\b("+
@@ -181,7 +187,6 @@ function wordIsReserved(word) {
 function wordIsNumber(word) {
     return word.match(/\b\d+/)
 }
-
 
 //----------------------------------------------------------------------------
 // use a match function to see if sucessfull in ALL file

--- a/syntaxes/systemverilog.tmLanguage.json
+++ b/syntaxes/systemverilog.tmLanguage.json
@@ -16,7 +16,7 @@
       "name": "keyword.other.systemverilog"
     },
     {
-      "match": "\\b(initial|always|wait|force|release|assign|always_comb|always_ff|always_latch|forever|repeat|while|for|if|iff|else|case|casex|casez|default|endcase|return|break|continue|do|foreach|randomize|with|inside|dist|clocking|cover|coverpoint|property|bins|binsof|illegal_bins|ignore_bins|randcase|modport|matches|solve|static|assert|assume|before|expect|bind|extends|sequence|var|cross|ref|first_match|srandom|time|struct|packed|final|chandle|alias|tagged|extern|throughout|timeprecision|timeunit|priority|type|union|unique|uwire|wait_order|triggered|randsequence|import|export|context|pure|intersect|wildcard|within|virtual|local|const|typedef|enum|protected|this|super|endmodule|endfunction|endprimitive|endclass|endpackage|endsequence|endprogram|endclocking|endproperty|endgroup|endinterface)\\b",
+      "match": "\\b(initial|always|wait|force|release|assign|always_comb|always_ff|always_latch|forever|repeat|while|for|if|iff|else|case|casex|casez|default|endcase|return|break|continue|do|foreach|randomize|with|inside|dist|clocking|cover|coverpoint|property|bins|binsof|illegal_bins|ignore_bins|randcase|modport|matches|solve|static|assert|assume|before|expect|bind|extends|sequence|cross|ref|first_match|srandom|time|struct|packed|final|chandle|alias|tagged|extern|throughout|timeprecision|timeunit|priority|union|unique|uwire|wait_order|triggered|randsequence|import|export|context|pure|intersect|wildcard|within|virtual|local|const|typedef|enum|protected|this|super|endmodule|endfunction|endprimitive|endclass|endpackage|endsequence|endprogram|endclocking|endproperty|endgroup|endinterface)\\b",
       "name": "keyword.control.systemverilog"
     },
 
@@ -26,8 +26,14 @@
     },
 
     {
-      "match": "^[ ]*\\.\\s*\\w+\\b",
-      "name": "variable.parameter.systemverilog"
+      "captures": {
+        "1": {
+          "name": "variable.parameter.systemverilog"
+        }
+
+      },
+      "match": "[ |\\W]+(\\.\\s*\\w+\\b)",
+      "name": "meta.include.systemverilog"
     },
 
     {
@@ -82,23 +88,12 @@
       "include": "#all-types"
     },
     {
-      "match": "(=|!=|<|>|@|#)",
+      "match": "(= | != | < | > | @ | # | \\- | \\+ | \\* | \\/ | % | !| &&  | \\| | \\bor\\b)",
       "name": "support.function.systemverilog"
     },
+
     {
-      "match": "(\\-|\\+|\\*|\\/|%)",
-      "name": "support.function.systemverilog"
-    },
-    {
-      "match": "(!|&&|\\|\\||\\bor\\b)",
-      "name": "support.function.systemverilog"
-    },
-    {
-      "match": "(&|\\||\\^|~|\\?)",
-      "name": "support.function.systemverilog"
-    },
-    {
-      "match": "({|}|:|;|,)",
+      "match": "(& |  | \\^ | ~ | \\? | {|} | : | ; | ,)",
       "name": "support.function.systemverilog"
     },
 
@@ -136,7 +131,7 @@
       "name": "constant.numeric.systemverilog"
     },
     {
-      "match": "\\b\\d+\\b",
+      "match": "\\b[0-9_]+\\b",
       "name": "constant.numeric.systemverilog"
     },
     {
@@ -186,7 +181,7 @@
       ]
     },
     "storage-type-systemverilog": {
-      "match": "\\b(wire|tri|tri[01]|supply[01]|wand|triand|wor|trior|trireg|reg|parameter|integer|rand|randc|int|longint|shortint|logic|bit|byte|shortreal|string)\\b",
+      "match": "\\b(wire|tri|tri[01]|supply[01]|wand|triand|wor|trior|trireg|reg|parameter|integer|rand|randc|int|longint|shortint|logic|bit|byte|shortreal|string|type|var\\s+type)\\b",
       "name": "storage.type.systemverilog"
     },
     "storage-modifier-systemverilog": {


### PR DESCRIPTION
Fix bug crash when the signal of '.' is not found (happen in comment for example)
Better support of type and var type, for struct completion and signal autocompletion
Var type, type are in blue like int, bit, logic...
Fix issue where the .something was apply color correctly